### PR TITLE
Replace deprecated CRM_Core_OptionGroup::getValue()

### DIFF
--- a/CRM/Petitionemail/Form/Report/PetitionEmail.php
+++ b/CRM/Petitionemail/Form/Report/PetitionEmail.php
@@ -111,7 +111,7 @@ class CRM_Petitionemail_Form_Report_PetitionEmail extends CRM_Report_Form {
       $group_id = intval($this->_params['group_id_value']);
     }
     $petition_activity_type_id = 
-      intval(CRM_Core_OptionGroup::getValue('activity_type', 'Petition', 'name'));
+      intval(\CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Petition'));
     $activityContacts =
       CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
     $source_activity_record_type_id =
@@ -188,7 +188,7 @@ class CRM_Petitionemail_Form_Report_PetitionEmail extends CRM_Report_Form {
     $target_activity_record_type_id =
       intval(CRM_Utils_Array::key('Activity Targets', $activityContacts));
     $email_activity_type_id = 
-      intval(CRM_Core_OptionGroup::getValue('activity_type', 'Email', 'name'));
+      intval(\CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email'));
 
     $sql = "SELECT DISTINCT c.id, display_name FROM civicrm_contact c JOIN
       civicrm_activity_contact ac ON c.id = ac.contact_id WHERE record_type_id = %0

--- a/petitionemail.php
+++ b/petitionemail.php
@@ -1217,7 +1217,7 @@ function petitionemail_is_actionable_activity($activity_id) {
   if(!petitionemail_get_petition_id_for_activity($activity_id)) {
     return FALSE;
   }
-  $completed = CRM_Core_OptionGroup::getValue('activity_status', 'Completed', 'name');
+  $completed = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed');
   $sql = "SELECT id FROM civicrm_activity WHERE id = %0 AND status_id = %1";
   $params = array(0 => array($activity_id, 'Integer'), 1 => array($completed, 'Integer'));
   $dao = CRM_Core_DAO::executeQuery($sql, $params);


### PR DESCRIPTION
Civi 5.60 removes `CRM_Core_OptionGroup::getValue()`. This updates the code to the non-deprecated equivalent.